### PR TITLE
Add WIP placeholder, styles and projects

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -31,4 +34,4 @@ jobs:
       with:
         branch: gh-pages  # The branch the action should deploy to.
         folder: build     # The folder the action should deploy.
-        token: ${{ secrets.GH_PAGES_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/public/wip-placeholder.svg
+++ b/public/wip-placeholder.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#293a69" rx="12"/>
+  <rect x="20" y="20" width="360" height="260" fill="none" stroke="#ffffff" stroke-width="2" stroke-dasharray="10,6" rx="8"/>
+  <text x="200" y="130" text-anchor="middle" font-family="Poppins, sans-serif" font-size="28" font-weight="bold" fill="#ffffff">🚧</text>
+  <text x="200" y="170" text-anchor="middle" font-family="Poppins, sans-serif" font-size="24" font-weight="bold" fill="#ffffff">Work in Progress</text>
+  <text x="200" y="210" text-anchor="middle" font-family="Poppins, sans-serif" font-size="14" fill="#aab4d0">Check back soon!</text>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -98,6 +98,29 @@ header nav ul li a {
   flex: 0 0 45%;
 }
 
+.wip-project {
+  position: relative;
+  opacity: 0.9;
+}
+
+.wip-badge {
+  background: #e67e22;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: bold;
+  padding: 4px 12px;
+  border-radius: 4px;
+  display: inline-block;
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+}
+
+.wip-project img {
+  width: 100%;
+  max-width: 400px;
+  border-radius: 8px;
+}
+
 .project img {
   width: auto;      /* Width can adjust to maintain aspect ratio */
   height: 400px;    /* Fixed height for all images */

--- a/src/Portfolio.js
+++ b/src/Portfolio.js
@@ -28,14 +28,27 @@ function Portfolio() {
             <p>This app depends on a small db to spin up for usage which takes a few seconds.</p>
             <a href="https://ruizj3.github.io/pill_and_bill/" class="my-link">View React App</a>
         </div>
-        {//commenting out until new project inserted
-        // <div class="project">
-        //    <img src="NodeGraph.png" alt="Project 3."></img>
-        //    <h3>Project Title 3</h3>
-        //    <p>Description of Project 3.</p>
-        //    <a href="link-to-project-3" class="my-link">View Project</a>
-        // </div>
-        }
+        <div class="project wip-project">
+            <div class="wip-badge">Work in Progress</div>
+            <img src="/wip-placeholder.svg" alt="Work in Progress - Fake Grocery Delivery Service"/>
+            <h3>Fake Grocery Delivery Service</h3>
+            <p>A simulated grocery delivery service application.</p>
+            <a href="https://github.com/ruizj3/fake_grocery_delivery_service" class="my-link" target="_blank" rel="noopener noreferrer">View Repo</a>
+        </div>
+        <div class="project wip-project">
+            <div class="wip-badge">Work in Progress</div>
+            <img src="/wip-placeholder.svg" alt="Work in Progress - Fake Grocery Delivery Time Prediction"/>
+            <h3>Fake Grocery Delivery Time Prediction</h3>
+            <p>Predicting delivery times for a simulated grocery delivery service.</p>
+            <a href="https://github.com/ruizj3/fake_grocery_delivery_time_prediction" class="my-link" target="_blank" rel="noopener noreferrer">View Repo</a>
+        </div>
+        <div class="project wip-project">
+            <div class="wip-badge">Work in Progress</div>
+            <img src="/wip-placeholder.svg" alt="Work in Progress - Receipt OCR"/>
+            <h3>Receipt OCR</h3>
+            <p>Optical character recognition for receipts.</p>
+            <a href="https://github.com/ruizj3/receipt-ocr" class="my-link" target="_blank" rel="noopener noreferrer">View Repo</a>
+        </div>
 </section>
     );
 }


### PR DESCRIPTION
Add a reusable work-in-progress SVG placeholder (public/wip-placeholder.svg), new CSS for .wip-project and .wip-badge (styling, badge, image sizing), and replace the commented-out project with three WIP project entries in src/Portfolio.js (Fake Grocery Delivery Service, Fake Grocery Delivery Time Prediction, Receipt OCR). Each project uses the placeholder image and links to the respective GitHub repos (open in a new tab with noopener noreferrer). Improves portfolio visibility for in-progress work.